### PR TITLE
Login form fix

### DIFF
--- a/src/app/account-access/login/screen.tsx
+++ b/src/app/account-access/login/screen.tsx
@@ -1,5 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import Constants from 'expo-constants';
+import { isEmpty } from 'lodash';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { View } from 'react-native';
@@ -53,7 +54,7 @@ export function LoginScreen(): JSX.Element {
         <View style={style.footer}>
           <AppButton
             isLoading={isSubmitting}
-            isDisabled={!formState.isValid && formState.isSubmitted}
+            isDisabled={!isEmpty(formState.errors) && formState.isSubmitted}
             testID='submit-button'
             title={translate('BUTTON_SUBMIT')}
             onPress={handleSubmit(formSubmitted)}


### PR DESCRIPTION
If the valid form was submitted and before it was not submitted invalid `formState.errors` is an empty object, but `formState.isValid` equals `false`. That's why `isDisabled` was `true` and the button turned dark gray. Now it stays blue in this case